### PR TITLE
Porting to dropwizard 1.0.0-rc3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jdk-version>1.7</jdk-version>
+        <jdk-version>1.8</jdk-version>
 
         <gpg.useagent>true</gpg.useagent>
 
@@ -41,12 +41,12 @@
         <maven-gpg-plugin-version>1.6</maven-gpg-plugin-version>
         <maven-install-plugin-version>2.5.2</maven-install-plugin-version>
 
-        <dropwizard-version>0.9.1</dropwizard-version>
+        <dropwizard-version>1.0.0-rc3</dropwizard-version>
         <curator-version>2.9.1</curator-version>
         <mybatis-version>3.2.8</mybatis-version>
         <hsqldb-version>2.3.2</hsqldb-version>
-        <guice-bridge-version>2.4.0-b31</guice-bridge-version>  <!-- must match Dropwizard's HK2 version -->
-        <jackson-module-guice-version>2.6.3</jackson-module-guice-version>  <!-- must match Dropwizard's Jackson version -->
+        <guice-bridge-version>2.4.0-b34</guice-bridge-version>  <!-- must match Dropwizard's HK2 version -->
+        <jackson-module-guice-version>2.7.4</jackson-module-guice-version>  <!-- must match Dropwizard's Jackson version -->
     </properties>
 
     <name>Soabase</name>

--- a/soabase-admin/src/main/java/io/soabase/admin/AdminConsoleAppBuilder.java
+++ b/soabase-admin/src/main/java/io/soabase/admin/AdminConsoleAppBuilder.java
@@ -15,19 +15,24 @@
  */
 package io.soabase.admin;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+import javax.validation.Validator;
+
 import io.dropwizard.Configuration;
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.configuration.ConfigurationFactoryFactory;
+import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.soabase.admin.auth.AuthSpec;
 import io.soabase.admin.components.MetricComponent;
 import io.soabase.admin.components.StandardComponents;
 import io.soabase.admin.components.TabComponent;
 import io.soabase.admin.details.BundleSpec;
-import javax.validation.Validator;
-import java.util.List;
 
 public class AdminConsoleAppBuilder<T extends Configuration>
 {
@@ -64,7 +69,7 @@ public class AdminConsoleAppBuilder<T extends Configuration>
             @Override
             public ConfigurationFactory<T> create(Class<T> klass, Validator validator, ObjectMapper objectMapper, String propertyPrefix)
             {
-                return new ConfigurationFactory<>(configurationClass, validator, objectMapper, propertyPrefix);
+                return new YamlConfigurationFactory<>(configurationClass, validator, objectMapper, propertyPrefix);
             }
         };
         return this;

--- a/soabase-core/src/main/java/io/soabase/core/SoaBundle.java
+++ b/soabase-core/src/main/java/io/soabase/core/SoaBundle.java
@@ -346,7 +346,7 @@ public class SoaBundle<T extends Configuration> implements ConfiguredBundle<T>
         jerseyEnvironment.register(LoggingApis.class);
         jerseyEnvironment.register(binder);
         jerseyEnvironment.setUrlPattern(jerseyConfig.getUrlPattern());
-        jerseyEnvironment.register(new JacksonMessageBodyProvider(environment.getObjectMapper(), environment.getValidator()));
+        jerseyEnvironment.register(new JacksonMessageBodyProvider(environment.getObjectMapper()));
 
         checkCorsFilter(configuration, environment.admin());
         checkAdminGuiceFeature(environment, jerseyEnvironment);


### PR DESCRIPTION
Upgrading dependencies to match new dropwizard Jersey, Jackson, and HK2 versions.
